### PR TITLE
Make resolve and reject values optional in the TypeScript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,16 +2,16 @@ export interface DeferredPromise<ValueType> {
 	/**
 	Resolves the promise with a value or the result of another promise.
 
-	@param value - The value to resolve the promise with.
+	@param [value] - The value to resolve the promise with.
 	*/
-	resolve(value: ValueType | PromiseLike<ValueType>): void;
+	resolve(value?: ValueType | PromiseLike<ValueType>): void;
 
 	/**
 	Reject the promise with a provided reason or error.
 
-	@param reason - The reason or error to reject the promise with.
+	@param [reason] - The reason or error to reject the promise with.
 	*/
-	reject(reason: unknown): void;
+	reject(reason?: unknown): void;
 
 	/**
 	The deferred promise.

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,14 +2,14 @@ export interface DeferredPromise<ValueType> {
 	/**
 	Resolves the promise with a value or the result of another promise.
 
-	@param [value] - The value to resolve the promise with.
+	@param value - The value to resolve the promise with.
 	*/
 	resolve(value?: ValueType | PromiseLike<ValueType>): void;
 
 	/**
 	Reject the promise with a provided reason or error.
 
-	@param [reason] - The reason or error to reject the promise with.
+	@param reason - The reason or error to reject the promise with.
 	*/
 	reject(reason?: unknown): void;
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -4,6 +4,8 @@ import pDefer, {DeferredPromise} from '.';
 expectType<DeferredPromise<unknown>>(pDefer());
 expectType<DeferredPromise<string>>(pDefer<string>());
 
+pDefer<void>().resolve();
 pDefer<string>().resolve('foo');
+pDefer<void>().reject();
 pDefer<string>().reject(new Error('foo'));
 expectType<Promise<string>>(pDefer<string>().promise);


### PR DESCRIPTION
First of all, thanks for the new types! While upgrading I ran into an error trying to call `resolve()` without supplying a value, pretty sure it shouldn't required for either.