### PR TITLE
Update typings to explicitly not require a bound `this`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,14 +9,14 @@ export interface DeferredPromise<ValueType> {
 
 	@param value - The value to resolve the promise with.
 	*/
-	resolve(value?: ValueType | PromiseLike<ValueType>): void;
+	resolve(this: void, value?: ValueType | PromiseLike<ValueType>): void;
 
 	/**
 	Reject the promise with a provided reason or error.
 
 	@param reason - The reason or error to reject the promise with.
 	*/
-	reject(reason?: unknown): void;
+	reject(this: void, reason?: unknown): void;
 }
 
 /**


### PR DESCRIPTION
If a user attempts to destructure the defer object, it can get flagged by [@typescript-eslint/unbound-method](https://typescript-eslint.io/rules/unbound-method/).

The actual implementation does not at all require a reference to this (`resolve`+`reject` is the native value provided in the promise callback), but the typescript definitions do not make it clear, and since it is being pulled off a object, eslint thinks it _might_ need a reference to `this`.

Example: 
```ts
async () => {
    const { promise, resolve } = defer(); // eslint fails here

    setTimeout(() => resolve('<abc>'), 100);
    return promise;
};
```
(This example is an oversimplification, and not a great place to legitimately use this library, but enough to recreate the issue)

The solution is to just update the typing to explicitly declare the `this` as ignorable (`void`).